### PR TITLE
Fixing handling uppercase extensions and .jpeg

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -40,7 +40,7 @@ namespace ImageResizer
             var searchOption = resizeRecursively ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly;
             var validExtensions = new[] { ".jpg", ".png", ".bmp", ".gif", ".tif", ".tiff" };
             var files = resizeDirectory
-                ? Directory.EnumerateFiles(fileOrDirectoryArg, "*.*", searchOption).Where(f => validExtensions.Contains(Path.GetExtension(f)))
+                ? Directory.EnumerateFiles(fileOrDirectoryArg, "*.*", searchOption).Where(f => validExtensions.Contains(Path.GetExtension(f).ToLower()))
                 : new[] { fileOrDirectoryArg };
 
             var sizes = getSizes(args);

--- a/Program.cs
+++ b/Program.cs
@@ -38,7 +38,7 @@ namespace ImageResizer
             }
 
             var searchOption = resizeRecursively ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly;
-            var validExtensions = new[] { ".jpg", ".png", ".bmp", ".gif", ".tif", ".tiff" };
+            var validExtensions = new[] { ".jpg", ".jpeg", ".png", ".bmp", ".gif", ".tif", ".tiff" };
             var files = resizeDirectory
                 ? Directory.EnumerateFiles(fileOrDirectoryArg, "*.*", searchOption).Where(f => validExtensions.Contains(Path.GetExtension(f).ToLower()))
                 : new[] { fileOrDirectoryArg };

--- a/Resizer.cs
+++ b/Resizer.cs
@@ -53,6 +53,7 @@ namespace ImageResizer
         {
             switch (extension.ToLower())
             {
+                case ".jpeg":
                 case ".jpg":
                     return ImageFormat.Jpeg;
                 case ".png":


### PR DESCRIPTION
I made a very simple fix: ImageResizer wasn't handling files with uppercase file extensions (like `image.JPG`). They weren't processed at all, unfortunately, I have a bunch of these.

I also added `.jpeg` file extension as supported - it's pretty rare, but again: I have a few like this.